### PR TITLE
Require cross-referencing for exemplar files

### DIFF
--- a/shapes/sh-gufo.ttl
+++ b/shapes/sh-gufo.ttl
@@ -96,6 +96,8 @@ sh-gufo:Aspect-disjointWith-Object-shape
 
 sh-gufo:Aspect-shape
 	a sh:NodeShape ;
+	rdfs:comment "rdfs:seeAlso links other shapes that review this class."@en ;
+	rdfs:seeAlso sh-gufo:Aspect-disjointWith-Object-shape ;
 	sh:targetClass gufo:Aspect ;
 	sh:xone (
 		[
@@ -574,6 +576,16 @@ sh-gufo:NonSortal-shape
 		"rdfs:seeAlso links other shapes that review this class."@en
 		;
 	rdfs:seeAlso sh-gufo:NonSortal-disjointWith-Sortal-shape ;
+	.
+
+sh-gufo:Object-shape
+	a sh:NodeShape ;
+	rdfs:comment
+		"This shape is a reference placeholder."@en ,
+		"rdfs:seeAlso links other shapes that review this class."@en
+		;
+	rdfs:seeAlso sh-gufo:Aspect-disjointWith-Object-shape ;
+	sh:targetClass gufo:Object ;
 	.
 
 sh-gufo:Phase-disjointWith-Role-shape

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
+.qc.ttl
 exemplars-entailment.ttl
 exemplars-expanded.ttl
 monolithic.ttl

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -49,13 +49,37 @@ all: \
 	    --log-level=DEBUG
 	touch $@
 
+.qc.done.log: \
+  .qc.ttl \
+  sh-qc.ttl
+	source $(top_srcdir)/venv/bin/activate \
+	  && pyshacl \
+	    --shacl sh-qc.ttl \
+	    .qc.ttl
+	touch $@
+
+.qc.ttl: \
+  $(shape_ttls) \
+  exemplars.ttl \
+  exemplars_XFAIL.ttl
+	source $(top_srcdir)/venv/bin/activate \
+	  && rdfpipe \
+	    --output-format turtle \
+	    $(shape_ttls) \
+	    exemplars.ttl \
+	    exemplars_XFAIL.ttl \
+	    > _$@
+	mv _$@ $@
+
 check: \
+  .qc.done.log \
   .pytest.done.log \
   .pyshacl.done.log
 
 clean:
 	@rm -f \
 	  .*.done.log \
+	  .qc.ttl \
 	  exemplars-entailment.ttl \
 	  exemplars-expanded.ttl \
 	  monolithic.ttl

--- a/tests/exemplars.ttl
+++ b/tests/exemplars.ttl
@@ -6,6 +6,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh-gufo: <http://example.org/shapes/sh-gufo/> .
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
@@ -20,15 +21,18 @@ kb:ComparativeRelationship-20cf44b4-026f-4249-a2c3-408642012c0c
 		owl:ObjectProperty ,
 		gufo:ComparativeRelationshipType
 		;
+	rdfs:seeAlso sh-gufo:ComparativeRelationshipType-shape ;
 	.
 
 kb:ConcreteIndividual-44ed202f-162e-44a6-ac48-c4e6bbbaa0ab
 	a gufo:Event ;
 	gufo:hasBeginPoint kb:Instant-c0f8bb25-7fd6-4328-b8d7-617a887c5f3c ;
+	rdfs:seeAlso sh-gufo:hasBeginPoint-subjects-shape ;
 	.
 
 kb:Instant-c0f8bb25-7fd6-4328-b8d7-617a887c5f3c
 	a time:Instant ;
+	rdfs:seeAlso sh-gufo:hasBeginPoint-objects-shape ;
 	.
 
 kb:MaterialRelationship-95952b20-2c19-47e6-b567-b3998e7b3553
@@ -36,10 +40,12 @@ kb:MaterialRelationship-95952b20-2c19-47e6-b567-b3998e7b3553
 		owl:ObjectProperty ,
 		gufo:MaterialRelationshipType
 		;
+	rdfs:seeAlso sh-gufo:MaterialRelationshipType-shape ;
 	.
 
 kb:Object-cd1aeb20-f037-476e-a2ae-45be3c79c64d
 	a gufo:Object ;
+	rdfs:seeAlso sh-gufo:Object-shape ;
 	.
 
 kb:QualityType-3a0ff32d-9743-46e4-bdcd-e86777f98551
@@ -48,10 +54,12 @@ kb:QualityType-3a0ff32d-9743-46e4-bdcd-e86777f98551
 		owl:Class
 		;
 	rdfs:subClassOf gufo:Quality ;
+	rdfs:seeAlso sh-gufo:concernsQualityType-objects-shape ;
 	.
 
 kb:QualityValueAttributionSituation-d760ff9f-8b16-4628-9236-fbe77b372e27
 	a gufo:QualityValueAttributionSituation ;
 	gufo:concernsQualityType kb:QualityType-3a0ff32d-9743-46e4-bdcd-e86777f98551 ;
+	rdfs:seeAlso sh-gufo:QualityValueAttributionSituation-shape ;
 	.
 

--- a/tests/exemplars_XFAIL.ttl
+++ b/tests/exemplars_XFAIL.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh-gufo: <http://example.org/shapes/sh-gufo/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 kb:EndurantType-f6898a59-a3ec-4ed9-9b1d-0cd9a19d2663
@@ -11,6 +12,7 @@ kb:EndurantType-f6898a59-a3ec-4ed9-9b1d-0cd9a19d2663
 		owl:Class
 		;
 	rdfs:comment "This is expected to trigger a validation error for not satisfying the disjoint-union, exactly-one clauses in EndurantType review."@en ;
+	rdfs:seeAlso sh-gufo:EndurantType-shape ;
 	.
 
 kb:Kind-09ee8285-3c47-43a5-a850-5dcd15dfd535
@@ -18,6 +20,7 @@ kb:Kind-09ee8285-3c47-43a5-a850-5dcd15dfd535
 		gufo:Kind ,
 		owl:Class
 		;
+	rdfs:seeAlso sh-gufo:Kind-subclassOf-Kind-constraint ;
 	.
 
 kb:Kind-14caf9d8-940b-47dc-a27d-6a65ea22224b
@@ -27,6 +30,7 @@ kb:Kind-14caf9d8-940b-47dc-a27d-6a65ea22224b
 		;
 	rdfs:subClassOf kb:Kind-09ee8285-3c47-43a5-a850-5dcd15dfd535 ;
 	rdfs:comment "This is expected to trigger a validation error for being a direct subclass of another Kind."@en ;
+	rdfs:seeAlso sh-gufo:Kind-subclassOf-Kind-constraint ;
 	.
 
 kb:Kind-5ef69346-4ca2-4303-93f7-c6b172db1fe7
@@ -34,6 +38,7 @@ kb:Kind-5ef69346-4ca2-4303-93f7-c6b172db1fe7
 		gufo:Kind ,
 		owl:Class
 		;
+	rdfs:seeAlso sh-gufo:Kind-subclassOf-Kind-constraint ;
 	.
 
 kb:Kind-93c29c13-6535-4242-b375-3cdf6a154c43
@@ -43,6 +48,7 @@ kb:Kind-93c29c13-6535-4242-b375-3cdf6a154c43
 		;
 	rdfs:subClassOf kb:SubKind-e5c100e5-5603-48bd-987c-d5d7535ff7cd ;
 	rdfs:comment "This is expected to trigger a validation error for being an indirect subclass of another Kind."@en ;
+	rdfs:seeAlso sh-gufo:Kind-subclassOf-Kind-constraint ;
 	.
 
 kb:SubKind-e5c100e5-5603-48bd-987c-d5d7535ff7cd
@@ -51,5 +57,6 @@ kb:SubKind-e5c100e5-5603-48bd-987c-d5d7535ff7cd
 		owl:Class
 		;
 	rdfs:subClassOf kb:Kind-5ef69346-4ca2-4303-93f7-c6b172db1fe7 ;
+	rdfs:seeAlso sh-gufo:Kind-subclassOf-Kind-constraint ;
 	.
 

--- a/tests/sh-qc.ttl
+++ b/tests/sh-qc.ttl
@@ -15,6 +15,7 @@ sh-qc:ExemplarLinksSHACLReviewer-shape
 	sh:message "Focus node should cross-reference some shape or SPARQL constraint for which it is supporting testing, using rdfs:seeAlso."@en ;
 	sh:or (
 		[
+			a sh:NodeShape ;
 			sh:or (
 				sh-qc:SHACLReviewer-shape
 				[
@@ -24,6 +25,7 @@ sh-qc:ExemplarLinksSHACLReviewer-shape
 			) ;
 		]
 		[
+			a sh:NodeShape ;
 			sh:property [
 				a sh:PropertyShape ;
 				sh:path rdfs:seeAlso ;

--- a/tests/sh-qc.ttl
+++ b/tests/sh-qc.ttl
@@ -1,0 +1,56 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sh-qc: <http://example.org/shapes/sh-gufo/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/shapes/sh-qc>
+	a owl:Ontology ;
+	rdfs:comment "This shapes graph serves in cross-checking exemplar graphs and shape graphs.  Exemplars are checked to include a reference-link to any shape or constraint.  Its typical usage is expected to be against a single graph-file combining an exemplars graph and a shapes graph, both scoped to a single vocabulary (e.g., a shapes and example-individuals graph both scoped to FOAF)."@en ;
+	.
+
+sh-qc:ExemplarLinksSHACLReviewer-shape
+	a sh:NodeShape ;
+	sh:message "Focus node should cross-reference some shape or SPARQL constraint for which it is supporting testing, using rdfs:seeAlso."@en ;
+	sh:or (
+		[
+			sh:or (
+				sh-qc:SHACLReviewer-shape
+				[
+					a sh:NodeShape ;
+					sh:class owl:Ontology ;
+				]
+			) ;
+		]
+		[
+			sh:property [
+				a sh:PropertyShape ;
+				sh:path rdfs:seeAlso ;
+				sh:qualifiedMinCount "1"^^xsd:integer ;
+				sh:qualifiedValueShape sh-qc:SHACLReviewer-shape ;
+			] ;
+		]
+	) ;
+	sh:targetSubjectsOf rdf:type ;
+	.
+
+sh-qc:SHACLReviewer-shape
+	a sh:NodeShape ;
+	rdfs:comment "This node shape is written for modularity, and hence has no targets specified."@en ;
+	sh:or (
+		[
+			a sh:NodeShape ;
+			sh:class sh:NodeShape ;
+		]
+		[
+			a sh:NodeShape ;
+			sh:class sh:PropertyShape ;
+		]
+		[
+			a sh:NodeShape ;
+			sh:class sh:SPARQLConstraint ;
+		]
+	) ;
+	.
+


### PR DESCRIPTION
This helped realize a class had not received a placeholder shape like other classes had.