### PR TITLE
Reduce `sh-gufo:categorizes-subjects-shape`

### DIFF
--- a/shapes/sh-gufo.ttl
+++ b/shapes/sh-gufo.ttl
@@ -975,23 +975,17 @@ sh-gufo:categorizes-objects-shape
 
 sh-gufo:categorizes-subjects-shape
 	a sh:NodeShape ;
-	sh:and (
-		[
-			a sh:NodeShape ;
-			sh:not [
-				a sh:NodeShape ;
-				sh:class gufo:AbstractIndividualType ;
-			] ;
-		]
-		[
-			a sh:NodeShape ;
-			sh:not [
-				a sh:NodeShape ;
-				sh:class gufo:ConcreteIndividualType ;
-			] ;
-		]
-	) ;
 	sh:class gufo:Type ;
+	sh:not
+		[
+			a sh:NodeShape ;
+			sh:class gufo:AbstractIndividualType ;
+		] ,
+		[
+			a sh:NodeShape ;
+			sh:class gufo:ConcreteIndividualType ;
+		]
+		;
 	sh:targetSubjectsOf gufo:categorizes ;
 	.
 


### PR DESCRIPTION
This patch removes a logically-redundant `sh:and`.

No effects were observed on Make-managed files.